### PR TITLE
Add pkg installation checks for car::Anova() and stats::aov() ARD functions

### DIFF
--- a/R/ard_car_anova.R
+++ b/R/ard_car_anova.R
@@ -8,7 +8,7 @@
 #' @return data frame
 #' @export
 #'
-#' @examplesIf do.call(asNamespace("cardx")$is_pkg_installed, list(pkg = c("broom.helpers", "car"), reference_pkg = "cardx"))
+#' @examplesIf do.call(asNamespace("cardx")$is_pkg_installed, list(pkg = c("broom.helpers", "car", "parameters"), reference_pkg = "cardx"))
 #' lm(AGE ~ ARM, data = cards::ADSL) |>
 #'   ard_car_anova()
 #'
@@ -18,7 +18,7 @@ ard_car_anova <- function(x, ...) {
   set_cli_abort_call()
 
   # check installed packages ---------------------------------------------------
-  check_pkg_installed(pkg = c("broom.helpers", "car"), reference_pkg = "cardx")
+  check_pkg_installed(pkg = c("broom.helpers", "car", "parameters"), reference_pkg = "cardx")
 
   # check inputs ---------------------------------------------------------------
   check_not_missing(x)

--- a/R/ard_stats_aov.R
+++ b/R/ard_stats_aov.R
@@ -10,13 +10,13 @@
 #' @return ARD data frame
 #' @export
 #'
-#' @examplesIf do.call(asNamespace("cardx")$is_pkg_installed, list(pkg = "broom.helpers", reference_pkg = "cardx"))
+#' @examplesIf do.call(asNamespace("cardx")$is_pkg_installed, list(pkg = c("broom.helpers", "parameters"), reference_pkg = "cardx"))
 #' ard_stats_aov(AGE ~ ARM, data = cards::ADSL)
 ard_stats_aov <- function(formula, data, ...) {
   set_cli_abort_call()
 
   # check installed packages ---------------------------------------------------
-  check_pkg_installed(c("broom.helpers"), reference_pkg = "cardx")
+  check_pkg_installed(c("broom.helpers", "parameters"), reference_pkg = "cardx")
 
   # check/process inputs -------------------------------------------------------
   check_not_missing(formula)

--- a/man/ard_car_anova.Rd
+++ b/man/ard_car_anova.Rd
@@ -18,7 +18,7 @@ data frame
 Function takes a regression model object and calculated ANOVA using \code{\link[car:Anova]{car::Anova()}}.
 }
 \examples{
-\dontshow{if (do.call(asNamespace("cardx")$is_pkg_installed, list(pkg = c("broom.helpers", "car"), reference_pkg = "cardx"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (do.call(asNamespace("cardx")$is_pkg_installed, list(pkg = c("broom.helpers", "car", "parameters"), reference_pkg = "cardx"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 lm(AGE ~ ARM, data = cards::ADSL) |>
   ard_car_anova()
 

--- a/man/ard_stats_aov.Rd
+++ b/man/ard_stats_aov.Rd
@@ -23,7 +23,7 @@ Analysis results data for Analysis of Variance.
 Calculated with \code{stats::aov()}
 }
 \examples{
-\dontshow{if (do.call(asNamespace("cardx")$is_pkg_installed, list(pkg = "broom.helpers", reference_pkg = "cardx"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (do.call(asNamespace("cardx")$is_pkg_installed, list(pkg = c("broom.helpers", "parameters"), reference_pkg = "cardx"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 ard_stats_aov(AGE ~ ARM, data = cards::ADSL)
 \dontshow{\}) # examplesIf}
 }

--- a/tests/testthat/test-ard_car_anova.R
+++ b/tests/testthat/test-ard_car_anova.R
@@ -1,5 +1,5 @@
 skip_if_not(
-  do.call(asNamespace("cardx")$is_pkg_installed, list(pkg = c("broom.helpers", "car"), reference_pkg = "cardx"))
+  is_pkg_installed(c("broom.helpers", "car", "parameters"), reference_pkg = "cardx")
 )
 
 test_that("ard_car_anova() works", {

--- a/tests/testthat/test-ard_stats_aov.R
+++ b/tests/testthat/test-ard_stats_aov.R
@@ -1,4 +1,4 @@
-skip_if_not(is_pkg_installed("broom.helpers", reference_pkg = "cardx"))
+skip_if_not(is_pkg_installed(c("broom.helpers", "parameters"), reference_pkg = "cardx"))
 
 test_that("ard_aov() works", {
   expect_error(


### PR DESCRIPTION
**What changes are proposed in this pull request?**
The `ard_stats_aov()` and `ard_car_anova()` functions didn't have checks for the installation of the {parameters} package for the examples and test files. They have now been added.

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] If a new `ard_*()` function was added, it passes the ARD structural checks from `cards::check_ard_structure()`.
- [ ] If a new `ard_*()` function was added, `set_cli_abort_call()` has been set.
- [ ] If a new `ard_*()` function was added and it depends on another package (such as, `broom`), `is_pkg_installed("broom", reference_pkg = "cardx")` has been set in the function call and the following added to the roxygen comments: `@examplesIf do.call(asNamespace("cardx")$is_pkg_installed, list(pkg = "broom"", reference_pkg = "cardx"))`
- [ ] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cardx (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
