### PR TITLE
Fix in ard_missing() for design variables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Update in `ard_categorical.survey.design()` for factor variables that are all missing. These variables can now be tabulated, where previously this resulted in an error. 
 
+* Update in `ard_missing.survey.design()` where we can now tabulate the missing rate of design variables, such as the weights.
+
 # cardx 0.2.2
 
 * Added a `data.frame` method to `ard_survival_survfit()`.

--- a/R/ard_missing.survey.design.R
+++ b/R/ard_missing.survey.design.R
@@ -54,7 +54,7 @@ ard_missing.survey.design <- function(data,
 
   # convert all variables to T/F whether it's missing --------------------------
   data$variables <- data$variables |>
-    dplyr::mutate(across(all_of(variables), Negate(is.na)))
+    dplyr::mutate(across(all_of(variables), Negate(is.na), .names = "lgl_{.col}"))
 
   cards::process_formula_selectors(
     data$variables[variables],
@@ -86,9 +86,12 @@ ard_missing.survey.design <- function(data,
   result <-
     ard_categorical(
       data = data,
-      variables = all_of(variables),
+      variables = all_of(paste0("lgl_", variables)),
       by = any_of(by),
       statistic = everything() ~ c("n", "N", "p", "n_unweighted", "N_unweighted", "p_unweighted")
+    ) |>
+    dplyr::mutate(
+      variable = str_remove(.data$variable, pattern = "^lgl_")
     )
 
   # rename the stats for missingness -------------------------------------------

--- a/tests/testthat/test-ard_missing.survey.design.R
+++ b/tests/testthat/test-ard_missing.survey.design.R
@@ -145,4 +145,3 @@ test_that("ard_missing.survey.design() works on design columns", {
     6.86651716
   )
 })
-

--- a/tests/testthat/test-ard_missing.survey.design.R
+++ b/tests/testthat/test-ard_missing.survey.design.R
@@ -112,3 +112,37 @@ test_that("ard_missing.survey.design() follows ard structure", {
       cards::check_ard_structure(method = FALSE)
   )
 })
+
+# testing bug reported here: https://github.com/ddsjoberg/gtsummary/issues/2092
+test_that("ard_missing.survey.design() works on design columns", {
+  expect_equal(
+    suppressWarnings(
+      dplyr::tribble(
+        ~region, ~year,          ~weights,
+        3,        1972, 0.663196271930943,
+        3,        1972, 0.917370028585327,
+        3,        1972, 0.897412512251031,
+        3,        1972,  1.06634082743438,
+        3,        1972,  0.94432371066466,
+        3,        1972, 0.526887241987567,
+        3,        1972, 0.526887241987567,
+        3,        1972, 0.546578869586901,
+        7,        1972, 0.283198307048893,
+        7,        1972, 0.494322145606406
+      ) %>%
+        survey::svydesign(
+          data = .,
+          ids = ~region,
+          strata = ~year,
+          weights = ~weights,
+          nest = TRUE
+        ) |>
+        ard_missing(variables = weights) |>
+        dplyr::filter(stat_name == "N_nonmiss") |>
+        dplyr::pull("stat") |>
+        getElement(1L)
+    ),
+    6.86651716
+  )
+})
+


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Update in `ard_missing.survey.design()` where we can now tabulate the missing rate of design variables, such as the weights.

**Reference GitHub issue associated with pull request.** _e.g., 'closes #<issue number>'_
https://github.com/ddsjoberg/gtsummary/issues/2092

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] If a new `ard_*()` function was added, it passes the ARD structural checks from `cards::check_ard_structure()`.
- [x] If a new `ard_*()` function was added, `set_cli_abort_call()` has been set.
- [x] If a new `ard_*()` function was added and it depends on another package (such as, `broom`), `is_pkg_installed("broom")` has been set in the function call and the following added to the roxygen comments: `@examplesIf do.call(asNamespace("cardx")$is_pkg_installed, list(pkg = "broom""))`
- [x] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cardx (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
