### PR TITLE
Adding `n` to the `proportion_ci*()` results

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,6 +44,7 @@ Suggests:
     survival (>= 3.6-4),
     testthat (>= 3.2.0),
     withr (>= 2.5.0)
+Remotes: insightsengineering/cards
 Config/Needs/website: insightsengineering/nesttemplate
 Config/testthat/edition: 3
 Config/testthat/parallel: true

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # cardx 0.2.2.9017
 
+* Little `n` is now returned with the results of the `proportion_ci_*()` functions, which then flows into the results of `ard_proportion_ci()`. (#256)
+
 * Update in `ard_categorical.survey.design()` for factor variables that are all missing. These variables can now be tabulated, where previously this resulted in an error. 
 
 * Update in `ard_missing.survey.design()` where we can now tabulate the missing rate of design variables, such as the weights.

--- a/R/proportion_ci.R
+++ b/R/proportion_ci.R
@@ -53,6 +53,7 @@ proportion_ci_wald <- function(x, conf.level = 0.95, correct = FALSE) {
 
   list(
     N = n,
+    n = sum(x),
     estimate = p_hat,
     conf.low = l_ci,
     conf.high = u_ci,
@@ -90,7 +91,11 @@ proportion_ci_wilson <- function(x, conf.level = 0.95, correct = FALSE) {
   n <- length(x)
   y <- stats::prop.test(x = sum(x), n = n, correct = correct, conf.level = conf.level)
 
-  list(N = n, conf.level = conf.level) |>
+  list(
+    N = n,
+    n = sum(x),
+    conf.level = conf.level
+  ) |>
     utils::modifyList(val = broom::tidy(y) |> as.list()) |>
     utils::modifyList(
       list(
@@ -126,7 +131,7 @@ proportion_ci_clopper_pearson <- function(x, conf.level = 0.95) {
 
   y <- stats::binom.test(x = sum(x), n = n, conf.level = conf.level)
 
-  list(N = n, conf.level = conf.level) |>
+  list(N = n, n = sum(x), conf.level = conf.level) |>
     utils::modifyList(val = broom::tidy(y) |> as.list()) |>
     utils::modifyList(list(method = "Clopper-Pearson Confidence Interval"))
 }
@@ -168,6 +173,7 @@ proportion_ci_agresti_coull <- function(x, conf.level = 0.95) {
 
   list(
     N = n,
+    n = sum(x),
     estimate = mean(x),
     conf.low = l_ci,
     conf.high = u_ci,
@@ -211,6 +217,7 @@ proportion_ci_jeffreys <- function(x, conf.level = 0.95) {
 
   list(
     N = n,
+    n = sum(x),
     estimate = mean(x),
     conf.low = l_ci,
     conf.high = u_ci,
@@ -351,6 +358,7 @@ proportion_ci_strat_wilson <- function(x,
   # Return values
   list(
     N = length(x),
+    n = sum(x),
     estimate = mean(x),
     conf.low = lower,
     conf.high = upper,

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -30,6 +30,7 @@ gtsummary
 mmrm
 pre
 quosures
+renv
 rlang's
 sd
 unlist

--- a/tests/testthat/_snaps/ard_proportion_ci.md
+++ b/tests/testthat/_snaps/ard_proportion_ci.md
@@ -3,15 +3,16 @@
     Code
       ard_categorical_ci_strat_wilson
     Message
-      {cards} data frame: 6 x 9
+      {cards} data frame: 7 x 9
     Output
         variable variable_level   context  stat_name stat_label      stat
       1      rsp           TRUE proporti…          N          N        80
-      2      rsp           TRUE proporti…   estimate   estimate     0.625
-      3      rsp           TRUE proporti…   conf.low   conf.low     0.487
-      4      rsp           TRUE proporti…  conf.high  conf.high     0.719
-      5      rsp           TRUE proporti… conf.level  conf.lev…      0.95
-      6      rsp           TRUE proporti…     method     method Stratifi…
+      2      rsp           TRUE proporti…          n          n        50
+      3      rsp           TRUE proporti…   estimate   estimate     0.625
+      4      rsp           TRUE proporti…   conf.low   conf.low     0.487
+      5      rsp           TRUE proporti…  conf.high  conf.high     0.719
+      6      rsp           TRUE proporti… conf.level  conf.lev…      0.95
+      7      rsp           TRUE proporti…     method     method Stratifi…
     Message
       i 3 more variables: fmt_fn, warning, error
 
@@ -20,15 +21,16 @@
     Code
       ard_categorical_ci_strat_wilsoncc
     Message
-      {cards} data frame: 6 x 9
+      {cards} data frame: 7 x 9
     Output
         variable variable_level   context  stat_name stat_label      stat
       1      rsp           TRUE proporti…          N          N        80
-      2      rsp           TRUE proporti…   estimate   estimate     0.625
-      3      rsp           TRUE proporti…   conf.low   conf.low     0.448
-      4      rsp           TRUE proporti…  conf.high  conf.high     0.753
-      5      rsp           TRUE proporti… conf.level  conf.lev…      0.95
-      6      rsp           TRUE proporti…     method     method Stratifi…
+      2      rsp           TRUE proporti…          n          n        50
+      3      rsp           TRUE proporti…   estimate   estimate     0.625
+      4      rsp           TRUE proporti…   conf.low   conf.low     0.448
+      5      rsp           TRUE proporti…  conf.high  conf.high     0.753
+      6      rsp           TRUE proporti… conf.level  conf.lev…      0.95
+      7      rsp           TRUE proporti…     method     method Stratifi…
     Message
       i 3 more variables: fmt_fn, warning, error
 

--- a/tests/testthat/_snaps/proportion_ci.md
+++ b/tests/testthat/_snaps/proportion_ci.md
@@ -21,6 +21,9 @@
       $N
       [1] 10
       
+      $n
+      [1] 5
+      
       $conf.level
       [1] 0.9
       
@@ -58,6 +61,9 @@
       proportion_ci_wilson(x_true)
     Output
       $N
+      [1] 32
+      
+      $n
       [1] 32
       
       $conf.level
@@ -98,6 +104,9 @@
     Output
       $N
       [1] 32
+      
+      $n
+      [1] 0
       
       $conf.level
       [1] 0.95
@@ -153,6 +162,9 @@
       $N
       [1] 10
       
+      $n
+      [1] 5
+      
       $estimate
       [1] 0.5
       
@@ -175,6 +187,9 @@
       proportion_ci_wald(x_true)
     Output
       $N
+      [1] 32
+      
+      $n
       [1] 32
       
       $estimate
@@ -200,6 +215,9 @@
     Output
       $N
       [1] 32
+      
+      $n
+      [1] 0
       
       $estimate
       [1] 0
@@ -234,6 +252,9 @@
     Output
       $N
       [1] 10
+      
+      $n
+      [1] 5
       
       $conf.level
       [1] 0.95
@@ -274,6 +295,9 @@
       $N
       [1] 32
       
+      $n
+      [1] 32
+      
       $conf.level
       [1] 0.95
       
@@ -312,6 +336,9 @@
     Output
       $N
       [1] 32
+      
+      $n
+      [1] 0
       
       $conf.level
       [1] 0.95
@@ -362,6 +389,9 @@
       $N
       [1] 10
       
+      $n
+      [1] 5
+      
       $estimate
       [1] 0.5
       
@@ -384,6 +414,9 @@
       proportion_ci_agresti_coull(x_true)
     Output
       $N
+      [1] 32
+      
+      $n
       [1] 32
       
       $estimate
@@ -409,6 +442,9 @@
     Output
       $N
       [1] 32
+      
+      $n
+      [1] 0
       
       $estimate
       [1] 0
@@ -444,6 +480,9 @@
       $N
       [1] 10
       
+      $n
+      [1] 5
+      
       $estimate
       [1] 0.5
       
@@ -466,6 +505,9 @@
       proportion_ci_jeffreys(x_true)
     Output
       $N
+      [1] 32
+      
+      $n
       [1] 32
       
       $estimate
@@ -491,6 +533,9 @@
     Output
       $N
       [1] 32
+      
+      $n
+      [1] 0
       
       $estimate
       [1] 0
@@ -533,6 +578,9 @@
       $N
       [1] 80
       
+      $n
+      [1] 50
+      
       $estimate
       [1] 0.625
       
@@ -558,6 +606,9 @@
       $N
       [1] 80
       
+      $n
+      [1] 50
+      
       $estimate
       [1] 0.625
       
@@ -582,6 +633,9 @@
       $N
       [1] 80
       
+      $n
+      [1] 50
+      
       $estimate
       [1] 0.625
       
@@ -605,6 +659,9 @@
     Output
       $N
       [1] 80
+      
+      $n
+      [1] 50
       
       $estimate
       [1] 0.625


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Little `n` is now returned with the results of the `proportion_ci_*()` functions, which then flows into the results of `ard_proportion_ci()`. (#256)

**Reference GitHub issue associated with pull request.** _e.g., 'closes #<issue number>'_
closes #256

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [x] **All** GitHub Action workflows pass with a :white_check_mark:
- [x] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [x] If a bug was fixed, a unit test was added.
- [x] If a new `ard_*()` function was added, it passes the ARD structural checks from `cards::check_ard_structure()`.
- [x] If a new `ard_*()` function was added, `set_cli_abort_call()` has been set.
- [x] If a new `ard_*()` function was added and it depends on another package (such as, `broom`), `is_pkg_installed("broom")` has been set in the function call and the following added to the roxygen comments: `@examplesIf do.call(asNamespace("cardx")$is_pkg_installed, list(pkg = "broom""))`
- [x] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`

Reviewer Checklist (if item does not apply, mark is as complete)

- [x] If a bug was fixed, a unit test was added.
- [x] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cardx (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
