### PR TITLE
`ard_survfit_survfit.data.frame()` can now construct unstratified model

### DIFF
--- a/man/ard_survival_survfit.Rd
+++ b/man/ard_survival_survfit.Rd
@@ -47,9 +47,9 @@ Must be one of the following:\tabular{ll}{
 an object of class \code{Surv} created using \code{\link[survival:Surv]{survival::Surv()}}. This object will be passed as the left-hand side of
 the formula constructed and passed to \code{\link[survival:survfit]{survival::survfit()}}. This object can also be passed as a string.}
 
-\item{variables}{(\code{character})\cr
+\item{variables}{(\code{\link[dplyr:dplyr_tidy_select]{tidy-select}})\cr
 stratification variables to be passed as the right-hand side of the formula constructed and passed to
-\code{\link[survival:survfit]{survival::survfit()}}.}
+\code{\link[survival:survfit]{survival::survfit()}}. Use \code{variables=NULL} for an unstratified model, e.g. \code{Surv() ~ 1}.}
 
 \item{method.args}{(named \code{list})\cr
 named list of arguments that will be passed to \code{\link[survival:survfit]{survival::survfit()}}.}

--- a/man/construction_helpers.Rd
+++ b/man/construction_helpers.Rd
@@ -78,9 +78,9 @@ environment is not applicable for quosures because they have
 their own environments.}
 
 \item{termlabels}{character vector giving the right-hand side of a
-    model formula.  Cannot be zero-length.}
+    model formula.  May be zero-length.}
 
-\item{response}{character string, symbol or call giving the left-hand
+\item{response}{a character string, symbol or call giving the left-hand
     side of a model formula, or \code{NULL}.}
 
 \item{intercept}{logical: should the formula have an intercept?}

--- a/tests/testthat/test-ard_survival_survfit.R
+++ b/tests/testthat/test-ard_survival_survfit.R
@@ -259,3 +259,16 @@ test_that("ard_survival_survfit.data.frame() works as expected", {
     class(mtcars$vs)
   )
 })
+
+test_that("ard_survival_survfit.data.frame(variables=NULL) for unstratified model", {
+  expect_equal(
+    cards::ADTTE |>
+      ard_survival_survfit(
+        y = ggsurvfit::Surv_CNSR(AVAL, CNSR),
+        variables = NULL,
+        times = 90
+      ),
+    survival::survfit(ggsurvfit::Surv_CNSR() ~ 1, data = cards::ADTTE) |>
+      ard_survival_survfit(times = 90)
+  )
+})


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Specifying `ard_survfit_survfit.data.frame(variables=NULL)` now creates an unstratified `survfit()` model, where previously `variables` argument could not be empty. (#277)
* The `ard_survfit_survfit.data.frame(variables)` now accepts tidyselect input. (#278)

**Reference GitHub issue associated with pull request.** _e.g., 'closes #<issue number>'_
closes #277
closes #278

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] If a new `ard_*()` function was added, it passes the ARD structural checks from `cards::check_ard_structure()`.
- [ ] If a new `ard_*()` function was added, `set_cli_abort_call()` has been set.
- [ ] If a new `ard_*()` function was added and it depends on another package (such as, `broom`), `is_pkg_installed("broom")` has been set in the function call and the following added to the roxygen comments: `@examplesIf do.call(asNamespace("cardx")$is_pkg_installed, list(pkg = "broom""))`
- [ ] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cardx (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
