### PR TITLE
Fix in `ard_survival_survfit.data.frame()` type conversion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Added function `ard_incidence_rate()` to calculate ARDs for incidence rate estimation. (#234)
 
+* Fix in `ard_survival_survfit.data.frame()` method where the stratifying variable was not correctly converted back to its original type.
+
 # cardx 0.2.4
 
 ## New Features and Updates

--- a/R/ard_continuous.survey.design.R
+++ b/R/ard_continuous.survey.design.R
@@ -376,8 +376,10 @@ accepted_svy_stats <- function(expand_quantiles = TRUE) {
 
   ard_nested <- ard |>
     tidyr::nest(..ard_data... = -c(cards::all_ard_groups(), cards::all_ard_variables())) |>
-    dplyr::arrange(across(c(cards::all_ard_groups(), cards::all_ard_variables()),
-                          ~ map(., as.character) |> unlist()))
+    dplyr::arrange(across(
+      c(cards::all_ard_groups(), cards::all_ard_variables()),
+      ~ map(., as.character) |> unlist()
+    ))
 
   # if all columns match, then replace the coerced character cols with their original type/class
   all_cols_equal <-

--- a/R/ard_continuous.survey.design.R
+++ b/R/ard_continuous.survey.design.R
@@ -376,7 +376,8 @@ accepted_svy_stats <- function(expand_quantiles = TRUE) {
 
   ard_nested <- ard |>
     tidyr::nest(..ard_data... = -c(cards::all_ard_groups(), cards::all_ard_variables())) |>
-    dplyr::arrange(across(c(cards::all_ard_groups(), cards::all_ard_variables()), unlist))
+    dplyr::arrange(across(c(cards::all_ard_groups(), cards::all_ard_variables()),
+                          ~ map(., as.character) |> unlist()))
 
   # if all columns match, then replace the coerced character cols with their original type/class
   all_cols_equal <-

--- a/man/construction_helpers.Rd
+++ b/man/construction_helpers.Rd
@@ -78,9 +78,9 @@ environment is not applicable for quosures because they have
 their own environments.}
 
 \item{termlabels}{character vector giving the right-hand side of a
-    model formula.  Cannot be zero-length.}
+    model formula.  May be zero-length.}
 
-\item{response}{character string, symbol or call giving the left-hand
+\item{response}{a character string, symbol or call giving the left-hand
     side of a model formula, or \code{NULL}.}
 
 \item{intercept}{logical: should the formula have an intercept?}

--- a/tests/testthat/test-ard_survival_survfit.R
+++ b/tests/testthat/test-ard_survival_survfit.R
@@ -293,7 +293,6 @@ test_that("ard_survival_survfit.data.frame() works as expected", {
       class(),
     class(cards::ADTTE$TRTA)
   )
-
 })
 
 test_that("ard_survival_survfit.data.frame(variables=NULL) for unstratified model", {

--- a/tests/testthat/test-ard_survival_survfit.R
+++ b/tests/testthat/test-ard_survival_survfit.R
@@ -276,6 +276,24 @@ test_that("ard_survival_survfit.data.frame() works as expected", {
       class(),
     class(mtcars$vs)
   )
+
+  # adding another check type
+  expect_silent(
+    tbl <-
+      ard_survival_survfit(
+        x = cards::ADTTE,
+        variables = "TRTA",
+        y = "survival::Surv(time = AVAL, event = 1 - CNSR, type = 'right', origin = 0)",
+        times = c(6, 12)
+      )
+  )
+  expect_equal(
+    cards::rename_ard_columns(tbl) |>
+      dplyr::pull("TRTA") |>
+      class(),
+    class(cards::ADTTE$TRTA)
+  )
+
 })
 
 test_that("ard_survival_survfit.data.frame(variables=NULL) for unstratified model", {


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Fix in `ard_survival_survfit.data.frame()` method where the stratifying variable was not correctly converted back to its original type.

--------------------------------------------------------------------------------

Pre-review Checklist (if item does not apply, mark is as complete)
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] PR branch has pulled the most recent updates from master branch: `usethis::pr_merge_main()`
- [ ] If a bug was fixed, a unit test was added.
- [ ] If a new `ard_*()` function was added, it passes the ARD structural checks from `cards::check_ard_structure()`.
- [ ] If a new `ard_*()` function was added, `set_cli_abort_call()` has been set.
- [ ] If a new `ard_*()` function was added and it depends on another package (such as, `broom`), `is_pkg_installed("broom")` has been set in the function call and the following added to the roxygen comments: `@examplesIf do.call(asNamespace("cardx")$is_pkg_installed, list(pkg = "broom""))`
- [ ] Code coverage is suitable for any new functions/features (generally, 100% coverage for new code): `devtools::test_coverage()`

Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] If a bug was fixed, a unit test was added.
- [ ] Code coverage is suitable for any new functions/features: `devtools::test_coverage()`

When the branch is ready to be merged:
- [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cardx (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] **All** GitHub Action workflows pass with a :white_check_mark:
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge" or "Rebase and merge".
