### PR TITLE
Use is_pkg_installed() directly

### DIFF
--- a/tests/testthat/test-ard_regression_basic.R
+++ b/tests/testthat/test-ard_regression_basic.R
@@ -1,4 +1,4 @@
-skip_if_not(do.call(asNamespace("cardx")$is_pkg_installed, list(pkg = "broom.helpers")))
+skip_if_not(is_pkg_installed("broom.helpers"))
 
 test_that("ard_regression_basic() works", {
   withr::local_options(list(width = 100))


### PR DESCRIPTION
testthat makes the cardx namespace available; this style results in ugly test log notes like:

```
• do.call(asNamespace("cardx")$is_pkg_installed, list(pkg = "broom.helpers"))
  is not TRUE (1): test-ard_regression_basic.R:1:1
• do.call(asNamespace("cardx")$is_pkg_installed, list(pkg = "broom")) is not
  TRUE (2): test-ard_proportion_ci.R:1:1, test-proportion_ci.R:1:1
• do.call(asNamespace("cardx")$is_pkg_installed, list(pkg = c("aod", (1):
  test-ard_aod_wald_test.R:1:1
```