### PR TITLE
Remove named argument to is_pkg_installed()

### DIFF
--- a/tests/testthat/test-ard_regression.R
+++ b/tests/testthat/test-ard_regression.R
@@ -1,4 +1,4 @@
-skip_if_not(is_pkg_installed(pkg = "broom.helpers"))
+skip_if_not(is_pkg_installed("broom.helpers"))
 
 test_that("ard_regression() works", {
   withr::local_options(list(width = 90))


### PR DESCRIPTION
Similar to #306 -- the `pkg=` part shows up in the skip message, so it's good to be consistent lest we wind up with two types of skip -- one with `pkg=` and one without -- that have the same actionable information ("install 'broom.helpers'").

This is the only call site (after #305, at least) that uses `pkg=`, so I opted for the smaller diff in picking a consistent style.