### PR TITLE
Add as_card(check=FALSE)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ BugReports: https://github.com/insightsengineering/cardx/issues
 Depends:
     R (>= 4.2)
 Imports:
-    cards (>= 0.7.0),
+    cards (>= 0.7.1.9005),
     cli (>= 3.6.1),
     dplyr (>= 1.2.0),
     glue (>= 1.6.2),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ BugReports: https://github.com/insightsengineering/cardx/issues
 Depends:
     R (>= 4.2)
 Imports:
-    cards (>= 0.7.1.9005),
+    cards (>= 0.7.1.9008),
     cli (>= 3.6.1),
     dplyr (>= 1.2.0),
     glue (>= 1.6.2),
@@ -46,6 +46,8 @@ Suggests:
     survival (>= 3.6-4),
     testthat (>= 3.2.0),
     withr (>= 2.5.0)
+Remotes:
+    insightsengineering/cards@main
 Config/Needs/website: insightsengineering/nesttemplate
 Config/testthat/edition: 3
 Config/testthat/parallel: true

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # cardx 0.3.2.9000
 
+* Added fix to ensure `as_card` does not error after update to `cards`
+
 # cardx 0.3.2
 
 * Swapped internal use of `dplyr::case_when()` for `dplyr::recode_values()` as the former is now deprecated. (#327)

--- a/R/ard_aod_wald_test.R
+++ b/R/ard_aod_wald_test.R
@@ -100,7 +100,7 @@ ard_aod_wald_test <- function(x, tidy_fun = broom.helpers::tidy_with_broom_or_pa
       warning = wald_test["warning"],
       error = wald_test["error"]
     ) |>
-    cards::as_card() |>
+    cards::as_card(check=FALSE) |>
     cards::tidy_ard_column_order()
 }
 

--- a/R/ard_aod_wald_test.R
+++ b/R/ard_aod_wald_test.R
@@ -100,7 +100,7 @@ ard_aod_wald_test <- function(x, tidy_fun = broom.helpers::tidy_with_broom_or_pa
       warning = wald_test["warning"],
       error = wald_test["error"]
     ) |>
-    cards::as_card(check=FALSE) |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order()
 }
 

--- a/R/ard_car_anova.R
+++ b/R/ard_car_anova.R
@@ -69,6 +69,6 @@ ard_car_anova <- function(x, ...) {
       warning = car_anova["warning"],
       error = car_anova["error"]
     ) |>
-    cards::as_card() |>
+    cards::as_card(check=FALSE) |>
     cards::tidy_ard_column_order()
 }

--- a/R/ard_car_anova.R
+++ b/R/ard_car_anova.R
@@ -69,6 +69,6 @@ ard_car_anova <- function(x, ...) {
       warning = car_anova["warning"],
       error = car_anova["error"]
     ) |>
-    cards::as_card(check=FALSE) |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order()
 }

--- a/R/ard_car_vif.R
+++ b/R/ard_car_vif.R
@@ -101,6 +101,6 @@ ard_car_vif <- function(x, ...) {
 
   # Clean up return object
   vif_return |>
-    cards::as_card() |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order()
 }

--- a/R/ard_categorical_ci.R
+++ b/R/ard_categorical_ci.R
@@ -97,7 +97,7 @@ ard_categorical_ci.data.frame <- function(data,
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check=FALSE))
   }
 
   # calculate confidence intervals ---------------------------------------------
@@ -148,7 +148,7 @@ ard_categorical_ci.data.frame <- function(data,
     dplyr::mutate(
       context = "proportion_ci"
     ) |>
-    cards::as_card() |>
+    cards::as_card(check=FALSE) |>
     cards::tidy_ard_column_order() |>
     cards::tidy_ard_row_order()
 }

--- a/R/ard_categorical_ci.R
+++ b/R/ard_categorical_ci.R
@@ -97,7 +97,7 @@ ard_categorical_ci.data.frame <- function(data,
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card(check=FALSE))
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   # calculate confidence intervals ---------------------------------------------
@@ -148,7 +148,7 @@ ard_categorical_ci.data.frame <- function(data,
     dplyr::mutate(
       context = "proportion_ci"
     ) |>
-    cards::as_card(check=FALSE) |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order() |>
     cards::tidy_ard_row_order()
 }

--- a/R/ard_categorical_ci.survey.design.R
+++ b/R/ard_categorical_ci.survey.design.R
@@ -52,7 +52,7 @@ ard_categorical_ci.survey.design <- function(data,
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check=FALSE))
   }
 
   # calculate and return ARD of one sample CI ----------------------------------
@@ -144,7 +144,7 @@ ard_categorical_ci.survey.design <- function(data,
       stat_label = .data$stat_name,
       fmt_fun = map(.data$stat, ~ case_switch(is.numeric(.x) ~ 2L, .default = as.character))
     ) |>
-    cards::as_card() |>
+    cards::as_card(check=FALSE) |>
     cards::tidy_ard_column_order() |>
     .restore_original_column_types(data = data$variables)
 

--- a/R/ard_categorical_ci.survey.design.R
+++ b/R/ard_categorical_ci.survey.design.R
@@ -52,7 +52,7 @@ ard_categorical_ci.survey.design <- function(data,
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card(check=FALSE))
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   # calculate and return ARD of one sample CI ----------------------------------
@@ -144,7 +144,7 @@ ard_categorical_ci.survey.design <- function(data,
       stat_label = .data$stat_name,
       fmt_fun = map(.data$stat, ~ case_switch(is.numeric(.x) ~ 2L, .default = as.character))
     ) |>
-    cards::as_card(check=FALSE) |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order() |>
     .restore_original_column_types(data = data$variables)
 

--- a/R/ard_continuous.survey.design.R
+++ b/R/ard_continuous.survey.design.R
@@ -97,7 +97,7 @@ ard_summary.survey.design <- function(data, variables, by = NULL,
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check=FALSE))
   }
 
   # compute the weighted statistics --------------------------------------------
@@ -161,7 +161,7 @@ ard_summary.survey.design <- function(data, variables, by = NULL,
   # add class and return ARD object --------------------------------------------
   df_stats |>
     dplyr::mutate(context = "continuous") |>
-    cards::as_card() |>
+    cards::as_card(check=FALSE) |>
     cards::tidy_ard_column_order()
 }
 
@@ -427,7 +427,7 @@ accepted_svy_stats <- function(expand_quantiles = TRUE) {
         tidyr::unnest(cols = "..ard_data...") |>
         dplyr::arrange(.data$...ard_id_for_sorting...) |>
         dplyr::select(-"...ard_id_for_sorting...") |>
-        cards::as_card()
+        cards::as_card(check=FALSE)
     )
   }
 

--- a/R/ard_continuous.survey.design.R
+++ b/R/ard_continuous.survey.design.R
@@ -97,7 +97,7 @@ ard_summary.survey.design <- function(data, variables, by = NULL,
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card(check=FALSE))
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   # compute the weighted statistics --------------------------------------------
@@ -161,7 +161,7 @@ ard_summary.survey.design <- function(data, variables, by = NULL,
   # add class and return ARD object --------------------------------------------
   df_stats |>
     dplyr::mutate(context = "continuous") |>
-    cards::as_card(check=FALSE) |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order()
 }
 
@@ -190,7 +190,6 @@ accepted_svy_stats <- function(expand_quantiles = TRUE) {
   }
   c(base_stats, "p##")
 }
-
 
 
 # this function calculates the summary for a single variable, single statistic
@@ -427,7 +426,7 @@ accepted_svy_stats <- function(expand_quantiles = TRUE) {
         tidyr::unnest(cols = "..ard_data...") |>
         dplyr::arrange(.data$...ard_id_for_sorting...) |>
         dplyr::select(-"...ard_id_for_sorting...") |>
-        cards::as_card(check=FALSE)
+        cards::as_card(check = FALSE)
     )
   }
 

--- a/R/ard_continuous_ci.R
+++ b/R/ard_continuous_ci.R
@@ -35,7 +35,7 @@ ard_continuous_ci.data.frame <- function(data, variables, by = dplyr::group_vars
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check=FALSE))
   }
 
   # calculate CIs --------------------------------------------------------------

--- a/R/ard_continuous_ci.R
+++ b/R/ard_continuous_ci.R
@@ -35,7 +35,7 @@ ard_continuous_ci.data.frame <- function(data, variables, by = dplyr::group_vars
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card(check=FALSE))
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   # calculate CIs --------------------------------------------------------------

--- a/R/ard_continuous_ci.survey.design.R
+++ b/R/ard_continuous_ci.survey.design.R
@@ -61,7 +61,7 @@ ard_continuous_ci.survey.design <- function(data,
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check=FALSE))
   }
 
   # calculate and return ARD of one sample CI ----------------------------------
@@ -146,7 +146,7 @@ ard_continuous_ci.survey.design <- function(data,
       stat_label = .data$stat_name,
       fmt_fun = map(.data$stat, ~ case_switch(is.numeric(.x) ~ 2L, .default = as.character))
     ) |>
-    cards::as_card() |>
+    cards::as_card(check=FALSE) |>
     cards::tidy_ard_column_order()
 }
 

--- a/R/ard_continuous_ci.survey.design.R
+++ b/R/ard_continuous_ci.survey.design.R
@@ -61,7 +61,7 @@ ard_continuous_ci.survey.design <- function(data,
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card(check=FALSE))
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   # calculate and return ARD of one sample CI ----------------------------------
@@ -146,7 +146,7 @@ ard_continuous_ci.survey.design <- function(data,
       stat_label = .data$stat_name,
       fmt_fun = map(.data$stat, ~ case_switch(is.numeric(.x) ~ 2L, .default = as.character))
     ) |>
-    cards::as_card(check=FALSE) |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order()
 }
 

--- a/R/ard_effectsize_cohens_d.R
+++ b/R/ard_effectsize_cohens_d.R
@@ -66,7 +66,7 @@ ard_effectsize_cohens_d <- function(data, by, variables, conf.level = 0.95, ...)
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check=FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -119,7 +119,7 @@ ard_effectsize_paired_cohens_d <- function(data, by, variables, id, conf.level =
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check=FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -207,6 +207,6 @@ ard_effectsize_paired_cohens_d <- function(data, by, variables, id, conf.level =
       by = "stat_name"
     ) |>
     dplyr::mutate(stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name)) |>
-    cards::as_card() |>
+    cards::as_card(check=FALSE) |>
     cards::tidy_ard_column_order()
 }

--- a/R/ard_effectsize_cohens_d.R
+++ b/R/ard_effectsize_cohens_d.R
@@ -66,7 +66,7 @@ ard_effectsize_cohens_d <- function(data, by, variables, conf.level = 0.95, ...)
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card(check=FALSE))
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -119,7 +119,7 @@ ard_effectsize_paired_cohens_d <- function(data, by, variables, id, conf.level =
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card(check=FALSE))
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -207,6 +207,6 @@ ard_effectsize_paired_cohens_d <- function(data, by, variables, id, conf.level =
       by = "stat_name"
     ) |>
     dplyr::mutate(stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name)) |>
-    cards::as_card(check=FALSE) |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order()
 }

--- a/R/ard_effectsize_hedges_g.R
+++ b/R/ard_effectsize_hedges_g.R
@@ -65,7 +65,7 @@ ard_effectsize_hedges_g <- function(data, by, variables, conf.level = 0.95, ...)
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check=FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -117,7 +117,7 @@ ard_effectsize_paired_hedges_g <- function(data, by, variables, id, conf.level =
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check=FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -190,6 +190,6 @@ ard_effectsize_paired_hedges_g <- function(data, by, variables, id, conf.level =
       by = "stat_name"
     ) |>
     dplyr::mutate(stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name)) |>
-    cards::as_card() |>
+    cards::as_card(check=FALSE) |>
     cards::tidy_ard_column_order()
 }

--- a/R/ard_effectsize_hedges_g.R
+++ b/R/ard_effectsize_hedges_g.R
@@ -65,7 +65,7 @@ ard_effectsize_hedges_g <- function(data, by, variables, conf.level = 0.95, ...)
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card(check=FALSE))
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -117,7 +117,7 @@ ard_effectsize_paired_hedges_g <- function(data, by, variables, id, conf.level =
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card(check=FALSE))
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -190,6 +190,6 @@ ard_effectsize_paired_hedges_g <- function(data, by, variables, id, conf.level =
       by = "stat_name"
     ) |>
     dplyr::mutate(stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name)) |>
-    cards::as_card(check=FALSE) |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order()
 }

--- a/R/ard_emmeans_contrast.R
+++ b/R/ard_emmeans_contrast.R
@@ -98,7 +98,7 @@ ard_emmeans_contrast <- function(data, formula, method,
       context = "emmeans_contrast",
     ) |>
     dplyr::filter(.data$stat_name != "variable_level") |>
-    cards::as_card() |>
+    cards::as_card(check=FALSE) |>
     cards::tidy_ard_column_order() |>
     cards::tidy_ard_row_order()
 }

--- a/R/ard_emmeans_contrast.R
+++ b/R/ard_emmeans_contrast.R
@@ -98,7 +98,7 @@ ard_emmeans_contrast <- function(data, formula, method,
       context = "emmeans_contrast",
     ) |>
     dplyr::filter(.data$stat_name != "variable_level") |>
-    cards::as_card(check=FALSE) |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order() |>
     cards::tidy_ard_row_order()
 }

--- a/R/ard_emmeans_emmeans.R
+++ b/R/ard_emmeans_emmeans.R
@@ -95,7 +95,7 @@ ard_emmeans_emmeans <- function(data,
     dplyr::filter(!is.na(.data$stat)) |>
     dplyr::filter(.data$stat_name != "variable_level") |>
     dplyr::arrange(.data$variable_level) |>
-    cards::as_card() |>
+    cards::as_card(check=FALSE) |>
     cards::tidy_ard_column_order() |>
     cards::tidy_ard_row_order()
 }

--- a/R/ard_emmeans_emmeans.R
+++ b/R/ard_emmeans_emmeans.R
@@ -95,7 +95,7 @@ ard_emmeans_emmeans <- function(data,
     dplyr::filter(!is.na(.data$stat)) |>
     dplyr::filter(.data$stat_name != "variable_level") |>
     dplyr::arrange(.data$variable_level) |>
-    cards::as_card(check=FALSE) |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order() |>
     cards::tidy_ard_row_order()
 }

--- a/R/ard_incidence_rate.R
+++ b/R/ard_incidence_rate.R
@@ -125,7 +125,7 @@ ard_incidence_rate <- function(data,
       stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name),
       context = "incidence_rate",
     ) |>
-    cards::as_card() |>
+    cards::as_card(check=FALSE) |>
     cards::tidy_ard_column_order() |>
     cards::tidy_ard_row_order()
 }

--- a/R/ard_incidence_rate.R
+++ b/R/ard_incidence_rate.R
@@ -125,7 +125,7 @@ ard_incidence_rate <- function(data,
       stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name),
       context = "incidence_rate",
     ) |>
-    cards::as_card(check=FALSE) |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order() |>
     cards::tidy_ard_row_order()
 }

--- a/R/ard_missing.survey.design.R
+++ b/R/ard_missing.survey.design.R
@@ -60,7 +60,7 @@ ard_missing.survey.design <- function(data,
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check=FALSE))
   }
 
   # convert all variables to T/F whether it's missing --------------------------
@@ -145,6 +145,6 @@ ard_missing.survey.design <- function(data,
   # return final object --------------------------------------------------------
   result |>
     dplyr::mutate(context = "missing") |>
-    cards::as_card() |>
+    cards::as_card(check=FALSE) |>
     cards::tidy_ard_column_order()
 }

--- a/R/ard_missing.survey.design.R
+++ b/R/ard_missing.survey.design.R
@@ -60,7 +60,7 @@ ard_missing.survey.design <- function(data,
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card(check=FALSE))
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   # convert all variables to T/F whether it's missing --------------------------
@@ -145,6 +145,6 @@ ard_missing.survey.design <- function(data,
   # return final object --------------------------------------------------------
   result |>
     dplyr::mutate(context = "missing") |>
-    cards::as_card(check=FALSE) |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order()
 }

--- a/R/ard_regression.R
+++ b/R/ard_regression.R
@@ -125,7 +125,7 @@ ard_regression.data.frame <- function(x, formula, method, method.args = list(), 
       by = "stat_name"
     ) |>
     dplyr::mutate(stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name)) |>
-    cards::as_card() |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order()
 }
 

--- a/R/ard_smd_smd.R
+++ b/R/ard_smd_smd.R
@@ -54,7 +54,7 @@ ard_smd_smd <- function(data, by, variables, std.error = TRUE, conf.level = 0.95
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check=FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -119,6 +119,6 @@ ard_smd_smd <- function(data, by, variables, std.error = TRUE, conf.level = 0.95
       by = "stat_name"
     ) |>
     dplyr::mutate(stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name)) |>
-    cards::as_card() |>
+    cards::as_card(check=FALSE) |>
     cards::tidy_ard_column_order()
 }

--- a/R/ard_smd_smd.R
+++ b/R/ard_smd_smd.R
@@ -54,7 +54,7 @@ ard_smd_smd <- function(data, by, variables, std.error = TRUE, conf.level = 0.95
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card(check=FALSE))
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -119,6 +119,6 @@ ard_smd_smd <- function(data, by, variables, std.error = TRUE, conf.level = 0.95
       by = "stat_name"
     ) |>
     dplyr::mutate(stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name)) |>
-    cards::as_card(check=FALSE) |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order()
 }

--- a/R/ard_stats_anova.R
+++ b/R/ard_stats_anova.R
@@ -199,6 +199,6 @@ ard_stats_anova.data.frame <- function(x,
           .default = .data$stat_name
         )
     ) |>
-    cards::as_card() |>
+    cards::as_card(check=FALSE) |>
     cards::tidy_ard_column_order()
 }

--- a/R/ard_stats_anova.R
+++ b/R/ard_stats_anova.R
@@ -199,6 +199,6 @@ ard_stats_anova.data.frame <- function(x,
           .default = .data$stat_name
         )
     ) |>
-    cards::as_card(check=FALSE) |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order()
 }

--- a/R/ard_stats_aov.R
+++ b/R/ard_stats_aov.R
@@ -63,6 +63,6 @@ ard_stats_aov <- function(formula, data, ...) {
       warning = aov["warning"],
       error = aov["error"]
     ) |>
-    cards::as_card() |>
+    cards::as_card(check=FALSE) |>
     cards::tidy_ard_column_order()
 }

--- a/R/ard_stats_aov.R
+++ b/R/ard_stats_aov.R
@@ -63,6 +63,6 @@ ard_stats_aov <- function(formula, data, ...) {
       warning = aov["warning"],
       error = aov["error"]
     ) |>
-    cards::as_card(check=FALSE) |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order()
 }

--- a/R/ard_stats_chisq_test.R
+++ b/R/ard_stats_chisq_test.R
@@ -36,7 +36,7 @@ ard_stats_chisq_test <- function(data, by, variables, ...) {
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check=FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -69,5 +69,5 @@ ard_stats_chisq_test <- function(data, by, variables, ...) {
     }
   ) |>
     dplyr::bind_rows() |>
-    cards::as_card()
+    cards::as_card(check=FALSE)
 }

--- a/R/ard_stats_chisq_test.R
+++ b/R/ard_stats_chisq_test.R
@@ -36,7 +36,7 @@ ard_stats_chisq_test <- function(data, by, variables, ...) {
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card(check=FALSE))
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -69,5 +69,5 @@ ard_stats_chisq_test <- function(data, by, variables, ...) {
     }
   ) |>
     dplyr::bind_rows() |>
-    cards::as_card(check=FALSE)
+    cards::as_card(check = FALSE)
 }

--- a/R/ard_stats_fisher_test.R
+++ b/R/ard_stats_fisher_test.R
@@ -39,7 +39,7 @@ ard_stats_fisher_test <- function(data, by, variables, conf.level = 0.95, ...) {
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -74,5 +74,5 @@ ard_stats_fisher_test <- function(data, by, variables, conf.level = 0.95, ...) {
     }
   ) |>
     dplyr::bind_rows() |>
-    cards::as_card()
+    cards::as_card(check = FALSE)
 }

--- a/R/ard_stats_kruskal_test.R
+++ b/R/ard_stats_kruskal_test.R
@@ -35,7 +35,7 @@ ard_stats_kruskal_test <- function(data, by, variables) {
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check=FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -64,5 +64,5 @@ ard_stats_kruskal_test <- function(data, by, variables) {
     }
   ) |>
     dplyr::bind_rows() |>
-    cards::as_card()
+    cards::as_card(check=FALSE)
 }

--- a/R/ard_stats_kruskal_test.R
+++ b/R/ard_stats_kruskal_test.R
@@ -35,7 +35,7 @@ ard_stats_kruskal_test <- function(data, by, variables) {
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card(check=FALSE))
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -64,5 +64,5 @@ ard_stats_kruskal_test <- function(data, by, variables) {
     }
   ) |>
     dplyr::bind_rows() |>
-    cards::as_card(check=FALSE)
+    cards::as_card(check = FALSE)
 }

--- a/R/ard_stats_mantelhaen_test.R
+++ b/R/ard_stats_mantelhaen_test.R
@@ -42,7 +42,7 @@ ard_stats_mantelhaen_test <- function(data, by, variables, strata, ...) {
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   dots <- dots_list(...)
@@ -69,7 +69,7 @@ ard_stats_mantelhaen_test <- function(data, by, variables, strata, ...) {
       stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name),
       context = "stats_mantelhaen_test",
     ) |>
-    cards::as_card() |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order() |>
     cards::tidy_ard_row_order()
 }

--- a/R/ard_stats_mcnemar_test.R
+++ b/R/ard_stats_mcnemar_test.R
@@ -60,7 +60,7 @@ ard_stats_mcnemar_test <- function(data, by, variables, ...) {
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check=FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -103,7 +103,7 @@ ard_stats_mcnemar_test_long <- function(data, by, variables, id, ...) {
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check=FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -169,7 +169,7 @@ ard_stats_mcnemar_test_long <- function(data, by, variables, id, ...) {
       by = "stat_name"
     ) |>
     dplyr::mutate(stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name)) |>
-    cards::as_card() |>
+    cards::as_card(check=FALSE) |>
     cards::tidy_ard_column_order()
 }
 

--- a/R/ard_stats_mcnemar_test.R
+++ b/R/ard_stats_mcnemar_test.R
@@ -60,7 +60,7 @@ ard_stats_mcnemar_test <- function(data, by, variables, ...) {
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card(check=FALSE))
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -103,7 +103,7 @@ ard_stats_mcnemar_test_long <- function(data, by, variables, id, ...) {
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card(check=FALSE))
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -169,7 +169,7 @@ ard_stats_mcnemar_test_long <- function(data, by, variables, id, ...) {
       by = "stat_name"
     ) |>
     dplyr::mutate(stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name)) |>
-    cards::as_card(check=FALSE) |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order()
 }
 

--- a/R/ard_stats_mood_test.R
+++ b/R/ard_stats_mood_test.R
@@ -42,7 +42,7 @@ ard_stats_mood_test <- function(data, by, variables, ...) {
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check=FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -101,7 +101,7 @@ ard_stats_mood_test <- function(data, by, variables, ...) {
       by = "stat_name"
     ) |>
     dplyr::mutate(stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name)) |>
-    cards::as_card() |>
+    cards::as_card(check=FALSE) |>
     cards::tidy_ard_column_order()
 }
 

--- a/R/ard_stats_mood_test.R
+++ b/R/ard_stats_mood_test.R
@@ -42,7 +42,7 @@ ard_stats_mood_test <- function(data, by, variables, ...) {
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card(check=FALSE))
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -101,7 +101,7 @@ ard_stats_mood_test <- function(data, by, variables, ...) {
       by = "stat_name"
     ) |>
     dplyr::mutate(stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name)) |>
-    cards::as_card(check=FALSE) |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order()
 }
 

--- a/R/ard_stats_oneway_test.R
+++ b/R/ard_stats_oneway_test.R
@@ -58,6 +58,6 @@ ard_stats_oneway_test <- function(formula, data, ...) {
       dplyr::tibble(!!!map(as.list(attr(stats::terms(formula), "variables"))[-1], as_label)) %>%
         set_names(., c("variable", paste0("group", seq_len(length(.) - 1L))))
     ) |>
-    cards::as_card() |>
+    cards::as_card(check=FALSE) |>
     cards::tidy_ard_column_order()
 }

--- a/R/ard_stats_oneway_test.R
+++ b/R/ard_stats_oneway_test.R
@@ -58,6 +58,6 @@ ard_stats_oneway_test <- function(formula, data, ...) {
       dplyr::tibble(!!!map(as.list(attr(stats::terms(formula), "variables"))[-1], as_label)) %>%
         set_names(., c("variable", paste0("group", seq_len(length(.) - 1L))))
     ) |>
-    cards::as_card(check=FALSE) |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order()
 }

--- a/R/ard_stats_poisson_test.R
+++ b/R/ard_stats_poisson_test.R
@@ -56,7 +56,7 @@ ard_stats_poisson_test <- function(data, variables, na.rm = TRUE, by = NULL, con
 
   # return empty ARD if no variables selected ----------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check=FALSE))
   }
 
   # check number of levels in `by`
@@ -147,7 +147,7 @@ ard_stats_poisson_test <- function(data, variables, na.rm = TRUE, by = NULL, con
       by = "stat_name"
     ) |>
     dplyr::mutate(stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name)) |>
-    cards::as_card() |>
+    cards::as_card(check=FALSE) |>
     cards::tidy_ard_column_order()
 }
 

--- a/R/ard_stats_poisson_test.R
+++ b/R/ard_stats_poisson_test.R
@@ -56,7 +56,7 @@ ard_stats_poisson_test <- function(data, variables, na.rm = TRUE, by = NULL, con
 
   # return empty ARD if no variables selected ----------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card(check=FALSE))
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   # check number of levels in `by`
@@ -147,7 +147,7 @@ ard_stats_poisson_test <- function(data, variables, na.rm = TRUE, by = NULL, con
       by = "stat_name"
     ) |>
     dplyr::mutate(stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name)) |>
-    cards::as_card(check=FALSE) |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order()
 }
 

--- a/R/ard_stats_prop_test.R
+++ b/R/ard_stats_prop_test.R
@@ -40,7 +40,7 @@ ard_stats_prop_test <- function(data, by, variables, conf.level = 0.95, ...) {
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check=FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -122,7 +122,7 @@ ard_stats_prop_test <- function(data, by, variables, conf.level = 0.95, ...) {
       by = "stat_name"
     ) |>
     dplyr::mutate(stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name)) |>
-    cards::as_card() |>
+    cards::as_card(check=FALSE) |>
     cards::tidy_ard_column_order()
 }
 

--- a/R/ard_stats_prop_test.R
+++ b/R/ard_stats_prop_test.R
@@ -40,7 +40,7 @@ ard_stats_prop_test <- function(data, by, variables, conf.level = 0.95, ...) {
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card(check=FALSE))
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -122,7 +122,7 @@ ard_stats_prop_test <- function(data, by, variables, conf.level = 0.95, ...) {
       by = "stat_name"
     ) |>
     dplyr::mutate(stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name)) |>
-    cards::as_card(check=FALSE) |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order()
 }
 

--- a/R/ard_stats_t_test.R
+++ b/R/ard_stats_t_test.R
@@ -62,7 +62,7 @@ ard_stats_t_test <- function(data, variables, by = NULL, conf.level = 0.95, ...)
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check=FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -108,7 +108,7 @@ ard_stats_paired_t_test <- function(data, by, variables, id, conf.level = 0.95, 
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check=FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -186,7 +186,7 @@ ard_stats_paired_t_test <- function(data, by, variables, id, conf.level = 0.95, 
       by = "stat_name"
     ) |>
     dplyr::mutate(stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name)) |>
-    cards::as_card() |>
+    cards::as_card(check=FALSE) |>
     cards::tidy_ard_column_order()
 }
 

--- a/R/ard_stats_t_test.R
+++ b/R/ard_stats_t_test.R
@@ -62,7 +62,7 @@ ard_stats_t_test <- function(data, variables, by = NULL, conf.level = 0.95, ...)
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card(check=FALSE))
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -108,7 +108,7 @@ ard_stats_paired_t_test <- function(data, by, variables, id, conf.level = 0.95, 
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card(check=FALSE))
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -186,7 +186,7 @@ ard_stats_paired_t_test <- function(data, by, variables, id, conf.level = 0.95, 
       by = "stat_name"
     ) |>
     dplyr::mutate(stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name)) |>
-    cards::as_card(check=FALSE) |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order()
 }
 

--- a/R/ard_stats_t_test_onesample.R
+++ b/R/ard_stats_t_test_onesample.R
@@ -35,7 +35,7 @@ ard_stats_t_test_onesample <- function(data, variables, by = dplyr::group_vars(d
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check=FALSE))
   }
 
   cards::ard_summary(
@@ -66,7 +66,7 @@ ard_stats_t_test_onesample <- function(data, variables, by = dplyr::group_vars(d
       stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name),
       context = "stats_t_test_onesample",
     ) |>
-    cards::as_card() |>
+    cards::as_card(check=FALSE) |>
     cards::tidy_ard_column_order() |>
     cards::tidy_ard_row_order()
 }

--- a/R/ard_stats_t_test_onesample.R
+++ b/R/ard_stats_t_test_onesample.R
@@ -35,7 +35,7 @@ ard_stats_t_test_onesample <- function(data, variables, by = dplyr::group_vars(d
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card(check=FALSE))
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   cards::ard_summary(
@@ -66,7 +66,7 @@ ard_stats_t_test_onesample <- function(data, variables, by = dplyr::group_vars(d
       stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name),
       context = "stats_t_test_onesample",
     ) |>
-    cards::as_card(check=FALSE) |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order() |>
     cards::tidy_ard_row_order()
 }

--- a/R/ard_stats_wilcox_test.R
+++ b/R/ard_stats_wilcox_test.R
@@ -62,7 +62,7 @@ ard_stats_wilcox_test <- function(data, variables, by = NULL, conf.level = 0.95,
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check=FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -114,7 +114,7 @@ ard_stats_paired_wilcox_test <- function(data, by, variables, id, conf.level = 0
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check=FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -196,7 +196,7 @@ ard_stats_paired_wilcox_test <- function(data, by, variables, id, conf.level = 0
       by = "stat_name"
     ) |>
     dplyr::mutate(stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name)) |>
-    cards::as_card() |>
+    cards::as_card(check=FALSE) |>
     cards::tidy_ard_column_order()
 }
 

--- a/R/ard_stats_wilcox_test.R
+++ b/R/ard_stats_wilcox_test.R
@@ -62,7 +62,7 @@ ard_stats_wilcox_test <- function(data, variables, by = NULL, conf.level = 0.95,
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card(check=FALSE))
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -114,7 +114,7 @@ ard_stats_paired_wilcox_test <- function(data, by, variables, id, conf.level = 0
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card(check=FALSE))
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -196,7 +196,7 @@ ard_stats_paired_wilcox_test <- function(data, by, variables, id, conf.level = 0
       by = "stat_name"
     ) |>
     dplyr::mutate(stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name)) |>
-    cards::as_card(check=FALSE) |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order()
 }
 

--- a/R/ard_stats_wilcox_test_onesample.R
+++ b/R/ard_stats_wilcox_test_onesample.R
@@ -35,7 +35,7 @@ ard_stats_wilcox_test_onesample <- function(data, variables, by = dplyr::group_v
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check=FALSE))
   }
 
   cards::ard_summary(
@@ -67,7 +67,7 @@ ard_stats_wilcox_test_onesample <- function(data, variables, by = dplyr::group_v
       stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name),
       context = "stats_wilcox_test_onesample",
     ) |>
-    cards::as_card() |>
+    cards::as_card(check=FALSE) |>
     cards::tidy_ard_column_order() |>
     cards::tidy_ard_row_order()
 }

--- a/R/ard_stats_wilcox_test_onesample.R
+++ b/R/ard_stats_wilcox_test_onesample.R
@@ -35,7 +35,7 @@ ard_stats_wilcox_test_onesample <- function(data, variables, by = dplyr::group_v
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card(check=FALSE))
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   cards::ard_summary(
@@ -67,7 +67,7 @@ ard_stats_wilcox_test_onesample <- function(data, variables, by = dplyr::group_v
       stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name),
       context = "stats_wilcox_test_onesample",
     ) |>
-    cards::as_card(check=FALSE) |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order() |>
     cards::tidy_ard_row_order()
 }

--- a/R/ard_survey_svychisq.R
+++ b/R/ard_survey_svychisq.R
@@ -41,7 +41,7 @@ ard_survey_svychisq <- function(data, by, variables, statistic = "F", ...) {
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check=FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -72,5 +72,5 @@ ard_survey_svychisq <- function(data, by, variables, statistic = "F", ...) {
     }
   ) |>
     dplyr::bind_rows() |>
-    cards::as_card()
+    cards::as_card(check=FALSE)
 }

--- a/R/ard_survey_svychisq.R
+++ b/R/ard_survey_svychisq.R
@@ -41,7 +41,7 @@ ard_survey_svychisq <- function(data, by, variables, statistic = "F", ...) {
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card(check=FALSE))
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -72,5 +72,5 @@ ard_survey_svychisq <- function(data, by, variables, statistic = "F", ...) {
     }
   ) |>
     dplyr::bind_rows() |>
-    cards::as_card(check=FALSE)
+    cards::as_card(check = FALSE)
 }

--- a/R/ard_survey_svyranktest.R
+++ b/R/ard_survey_svyranktest.R
@@ -41,7 +41,7 @@ ard_survey_svyranktest <- function(data, by, variables, test, ...) {
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check=FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -83,7 +83,7 @@ ard_survey_svyranktest <- function(data, by, variables, test, ...) {
       by = "stat_name"
     ) |>
     dplyr::mutate(stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name)) |>
-    cards::as_card() |>
+    cards::as_card(check=FALSE) |>
     cards::tidy_ard_column_order()
 }
 

--- a/R/ard_survey_svyranktest.R
+++ b/R/ard_survey_svyranktest.R
@@ -41,7 +41,7 @@ ard_survey_svyranktest <- function(data, by, variables, test, ...) {
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card(check=FALSE))
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -83,7 +83,7 @@ ard_survey_svyranktest <- function(data, by, variables, test, ...) {
       by = "stat_name"
     ) |>
     dplyr::mutate(stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name)) |>
-    cards::as_card(check=FALSE) |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order()
 }
 

--- a/R/ard_survey_svyttest.R
+++ b/R/ard_survey_svyttest.R
@@ -39,7 +39,7 @@ ard_survey_svyttest <- function(data, by, variables, conf.level = 0.95, ...) {
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check=FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -90,6 +90,6 @@ ard_survey_svyttest <- function(data, by, variables, conf.level = 0.95, ...) {
       by = "stat_name"
     ) |>
     dplyr::mutate(stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name)) |>
-    cards::as_card() |>
+    cards::as_card(check=FALSE) |>
     cards::tidy_ard_column_order()
 }

--- a/R/ard_survey_svyttest.R
+++ b/R/ard_survey_svyttest.R
@@ -39,7 +39,7 @@ ard_survey_svyttest <- function(data, by, variables, conf.level = 0.95, ...) {
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card(check=FALSE))
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   # build ARD ------------------------------------------------------------------
@@ -90,6 +90,6 @@ ard_survey_svyttest <- function(data, by, variables, conf.level = 0.95, ...) {
       by = "stat_name"
     ) |>
     dplyr::mutate(stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name)) |>
-    cards::as_card(check=FALSE) |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order()
 }

--- a/R/ard_survival_survdiff.R
+++ b/R/ard_survival_survdiff.R
@@ -95,7 +95,7 @@ ard_survival_survdiff <- function(formula, data, rho = 0, ...) {
         }
       )
     ) |>
-    cards::as_card() |>
+    cards::as_card(check=FALSE) |>
     cards::tidy_ard_column_order()
 }
 

--- a/R/ard_survival_survdiff.R
+++ b/R/ard_survival_survdiff.R
@@ -95,7 +95,7 @@ ard_survival_survdiff <- function(formula, data, rho = 0, ...) {
         }
       )
     ) |>
-    cards::as_card(check=FALSE) |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order()
 }
 

--- a/R/ard_survival_survfit.R
+++ b/R/ard_survival_survfit.R
@@ -452,7 +452,7 @@ extract_strata <- function(x, df_stat) {
       warning = list(NULL),
       error = list(NULL)
     ) %>%
-    cards::as_card() %>%
+    cards::as_card(check=FALSE) %>%
     cards::tidy_ard_column_order() %>%
     cards::tidy_ard_row_order()
 }

--- a/R/ard_survival_survfit.R
+++ b/R/ard_survival_survfit.R
@@ -452,7 +452,7 @@ extract_strata <- function(x, df_stat) {
       warning = list(NULL),
       error = list(NULL)
     ) %>%
-    cards::as_card(check=FALSE) %>%
+    cards::as_card(check = FALSE) %>%
     cards::tidy_ard_column_order() %>%
     cards::tidy_ard_row_order()
 }

--- a/R/ard_survival_survfit_diff.R
+++ b/R/ard_survival_survfit_diff.R
@@ -116,6 +116,6 @@ ard_survival_survfit_diff <- function(x, times, conf.level = 0.95) {
         ),
       context = "survival_survfit_diff",
     ) |>
-    cards::as_card() |>
+    cards::as_card(check=FALSE) |>
     cards::tidy_ard_column_order()
 }

--- a/R/ard_survival_survfit_diff.R
+++ b/R/ard_survival_survfit_diff.R
@@ -116,6 +116,6 @@ ard_survival_survfit_diff <- function(x, times, conf.level = 0.95) {
         ),
       context = "survival_survfit_diff",
     ) |>
-    cards::as_card(check=FALSE) |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order()
 }

--- a/R/ard_tabulate.survey.design.R
+++ b/R/ard_tabulate.survey.design.R
@@ -87,7 +87,7 @@ ard_tabulate.survey.design <- function(data,
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check=FALSE))
   }
 
   check_na_factor_levels(data$variables, c(by, variables))
@@ -230,7 +230,7 @@ ard_tabulate.survey.design <- function(data,
       warning = list(NULL),
       error = list(NULL),
     ) |>
-    cards::as_card() |>
+    cards::as_card(check=FALSE) |>
     cards::tidy_ard_column_order() |>
     cards::tidy_ard_row_order()
 }

--- a/R/ard_tabulate.survey.design.R
+++ b/R/ard_tabulate.survey.design.R
@@ -87,7 +87,7 @@ ard_tabulate.survey.design <- function(data,
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card(check=FALSE))
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   check_na_factor_levels(data$variables, c(by, variables))
@@ -145,7 +145,6 @@ ard_tabulate.survey.design <- function(data,
       call = get_cli_abort_call()
     )
   }
-
 
 
   # calculate counts -----------------------------------------------------------
@@ -230,7 +229,7 @@ ard_tabulate.survey.design <- function(data,
       warning = list(NULL),
       error = list(NULL),
     ) |>
-    cards::as_card(check=FALSE) |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order() |>
     cards::tidy_ard_row_order()
 }

--- a/R/ard_tabulate_abnormal.R
+++ b/R/ard_tabulate_abnormal.R
@@ -126,7 +126,7 @@ ard_tabulate_abnormal <- function(data,
       stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name),
       context = "categorical_abnormal",
     ) |>
-    cards::as_card() |>
+    cards::as_card(check=FALSE) |>
     cards::tidy_ard_column_order() |>
     cards::tidy_ard_row_order()
 }

--- a/R/ard_tabulate_abnormal.R
+++ b/R/ard_tabulate_abnormal.R
@@ -126,7 +126,7 @@ ard_tabulate_abnormal <- function(data,
       stat_label = dplyr::coalesce(.data$stat_label, .data$stat_name),
       context = "categorical_abnormal",
     ) |>
-    cards::as_card(check=FALSE) |>
+    cards::as_card(check = FALSE) |>
     cards::tidy_ard_column_order() |>
     cards::tidy_ard_row_order()
 }

--- a/R/ard_tabulate_max.R
+++ b/R/ard_tabulate_max.R
@@ -76,7 +76,7 @@ ard_tabulate_max <- function(data,
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   lst_results <- lapply(

--- a/R/ard_tabulate_value.survey.design.R
+++ b/R/ard_tabulate_value.survey.design.R
@@ -59,7 +59,7 @@ ard_tabulate_value.survey.design <- function(data,
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card())
+    return(dplyr::tibble() |> cards::as_card(check=FALSE))
   }
 
   # calculate summary statistics -----------------------------------------------

--- a/R/ard_tabulate_value.survey.design.R
+++ b/R/ard_tabulate_value.survey.design.R
@@ -59,7 +59,7 @@ ard_tabulate_value.survey.design <- function(data,
 
   # return empty ARD if no variables selected ----------------------------------
   if (is_empty(variables)) {
-    return(dplyr::tibble() |> cards::as_card(check=FALSE))
+    return(dplyr::tibble() |> cards::as_card(check = FALSE))
   }
 
   # calculate summary statistics -----------------------------------------------

--- a/tests/testthat/test-ard_categorical_ci.survey.design.R
+++ b/tests/testthat/test-ard_categorical_ci.survey.design.R
@@ -24,7 +24,7 @@ test_that("ard_categorical_ci(variables)", {
 
   expect_equal(
     ard_categorical_ci(dclus1, variables = starts_with("xxxxxx")),
-    dplyr::tibble() |> cards::as_card()
+    dplyr::tibble() |> cards::as_card(check=FALSE)
   )
 
   # check all works with numeric variable

--- a/tests/testthat/test-ard_categorical_ci.survey.design.R
+++ b/tests/testthat/test-ard_categorical_ci.survey.design.R
@@ -24,7 +24,7 @@ test_that("ard_categorical_ci(variables)", {
 
   expect_equal(
     ard_categorical_ci(dclus1, variables = starts_with("xxxxxx")),
-    dplyr::tibble() |> cards::as_card(check=FALSE)
+    dplyr::tibble() |> cards::as_card(check = FALSE)
   )
 
   # check all works with numeric variable

--- a/tests/testthat/test-ard_continuous_ci.survey.design.R
+++ b/tests/testthat/test-ard_continuous_ci.survey.design.R
@@ -35,7 +35,7 @@ test_that("ard_continuous_ci(variables)", {
 
   expect_equal(
     ard_continuous_ci(dclus1, variables = starts_with("xxxxxx")),
-    dplyr::tibble() |> cards::as_card()
+    dplyr::tibble() |> cards::as_card(check=FALSE)
   )
 
   # check NA values don't affect result

--- a/tests/testthat/test-ard_continuous_ci.survey.design.R
+++ b/tests/testthat/test-ard_continuous_ci.survey.design.R
@@ -35,7 +35,7 @@ test_that("ard_continuous_ci(variables)", {
 
   expect_equal(
     ard_continuous_ci(dclus1, variables = starts_with("xxxxxx")),
-    dplyr::tibble() |> cards::as_card(check=FALSE)
+    dplyr::tibble() |> cards::as_card(check = FALSE)
   )
 
   # check NA values don't affect result

--- a/tests/testthat/test-ard_stats_t_test_onesample.R
+++ b/tests/testthat/test-ard_stats_t_test_onesample.R
@@ -45,7 +45,7 @@ test_that("ard_stats_t_test_onesample() works", {
       cards::ADSL,
       variables = character(0)
     ),
-    dplyr::tibble() |> cards::as_card()
+    dplyr::tibble() |> cards::as_card(check=FALSE)
   )
 })
 

--- a/tests/testthat/test-ard_stats_t_test_onesample.R
+++ b/tests/testthat/test-ard_stats_t_test_onesample.R
@@ -45,7 +45,7 @@ test_that("ard_stats_t_test_onesample() works", {
       cards::ADSL,
       variables = character(0)
     ),
-    dplyr::tibble() |> cards::as_card(check=FALSE)
+    dplyr::tibble() |> cards::as_card(check = FALSE)
   )
 })
 

--- a/tests/testthat/test-ard_stats_wilcox_test_onesample.R
+++ b/tests/testthat/test-ard_stats_wilcox_test_onesample.R
@@ -47,7 +47,7 @@ test_that("ard_stats_wilcox_test_onesample() works", {
       cards::ADSL,
       variables = character(0)
     ),
-    dplyr::tibble() |> cards::as_card()
+    dplyr::tibble() |> cards::as_card(check=FALSE)
   )
 })
 

--- a/tests/testthat/test-ard_stats_wilcox_test_onesample.R
+++ b/tests/testthat/test-ard_stats_wilcox_test_onesample.R
@@ -47,7 +47,7 @@ test_that("ard_stats_wilcox_test_onesample() works", {
       cards::ADSL,
       variables = character(0)
     ),
-    dplyr::tibble() |> cards::as_card(check=FALSE)
+    dplyr::tibble() |> cards::as_card(check = FALSE)
   )
 })
 


### PR DESCRIPTION
To align with https://github.com/insightsengineering/cards/pull/534 this adds `as_check=FALSE`.

Awkwardly this means that cardx will only work with the latest cards, as this argument will cause an error otherwise. I could alternatively add some code to check the package version and behave differently, but that doesn't seem great.